### PR TITLE
workflows: Add doxygen installation to build docs.

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
+    - name: Install Doxygen
+      run: sudo apt-get update && sudo apt-get install -y doxygen
     - name: Install required Python packages
       run: pip install -r docs/requirements.txt
     - name: Build docs from Makefile


### PR DESCRIPTION
#### Description of Change

Thank you for your contribution. Please provide a description of the pull request and complete the steps listed in the checklist below.
In doubt, please refer to the contributors guide: [CONTRIBUTING.md](https://github.com/Infineon/makers-devops/blob/main/README.md#contributing). Please also be aware of the [Code of Conduct](CODE_OF_CONDUCT.md).

Description:

This pull request updates the documentation build workflow by adding a step to install Doxygen, ensuring that the necessary tools are available for generating documentation.

* [`.github/workflows/docs_build.yml`](diffhunk://#diff-edb6672fa7dcb9af0bd76fda78ae452099603775ec3b666b17f092e055d92588R29-R30): Added a step to install Doxygen using `apt-get` in the `jobs:` section of the workflow file.

This is required for docs using doxygen without static html files, see https://github.com/Infineon/arduino-motix-btn99x0/pull/6