### PR TITLE
.github/workflows: Improve link checking.

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -16,7 +16,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --skip-missing --glob-ignore-case --hidden --no-ignore './**/*.md' './**/*.html' './**/*.rst'
+          args: --skip-missing --glob-ignore-case --hidden --accept 200,429 --max-concurrency=1 --no-ignore './**/*.md' './**/*.html' './**/*.rst'
           fail: true
           format: markdown
           jobSummary: true


### PR DESCRIPTION
Explicitly accept 429 (too many requests) response to avoid [false positives](https://github.com/Infineon/XMC-for-Arduino/actions/runs/16569627738/job/46861224038?pr=374).
Also, limit concurrency to avoid rate limiting.
Example run here: https://github.com/Infineon/arduino-core-psoc6/actions/runs/16601215306?pr=146